### PR TITLE
nit: copy the raw string returned from Rime API

### DIFF
--- a/src/modules.cc
+++ b/src/modules.cc
@@ -17,8 +17,8 @@ static bool file_exists(const char *fname) noexcept {
 }
 
 static void lua_init(lua_State *L) {
-  const char *user_dir = RimeGetUserDataDir();
-  const char *shared_dir = RimeGetSharedDataDir();
+  auto user_dir = std::string(RimeGetUserDataDir());
+  auto shared_dir = std::string(RimeGetSharedDataDir());
 
   types_init(L);
   lua_getglobal(L, "package");
@@ -35,8 +35,8 @@ static void lua_init(lua_State *L) {
   lua_setfield(L, -2, "path");
   lua_pop(L, 1);
 
-  const auto user_file = std::string(user_dir) + LUA_DIRSEP "rime.lua";
-  const auto shared_file = std::string(shared_dir) + LUA_DIRSEP "rime.lua";
+  const auto user_file = user_dir + LUA_DIRSEP "rime.lua";
+  const auto shared_file = shared_dir + LUA_DIRSEP "rime.lua";
 
   // use the user_file first
   // use the shared_file if the user_file doesn't exist

--- a/src/modules.cc
+++ b/src/modules.cc
@@ -17,8 +17,8 @@ static bool file_exists(const char *fname) noexcept {
 }
 
 static void lua_init(lua_State *L) {
-  auto user_dir = std::string(RimeGetUserDataDir());
-  auto shared_dir = std::string(RimeGetSharedDataDir());
+  const auto user_dir = std::string(RimeGetUserDataDir());
+  const auto shared_dir = std::string(RimeGetSharedDataDir());
 
   types_init(L);
   lua_getglobal(L, "package");


### PR DESCRIPTION
c_str() returned from local std::string are short lived. We'd better copy it to a new std::string in the same full-expression.

#67 is fixed in https://github.com/rime/librime/commit/78abaa8108e12e4421970714f223379b33179447
This change is nice to have, because it is safer to construct a string immediately. Otherwise the raw string is implicitly converted to std::string later anyway.