### PR TITLE
Dev02

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -385,7 +385,7 @@ namespace KeyEventReg {
 }
 
 namespace EngineReg {
-#define MAX_LEVEL 30
+#define MAX_LEVEL 1
   typedef Engine T;
   static int max_level=MAX_LEVEL;
   static int count_level=0;
@@ -406,11 +406,13 @@ namespace EngineReg {
       LOG(ERROR) << "error parsing input: '" << repr << "'";
       return False;
     }
-    if ( max_level <= count_level++ ){
+    if ( max_level <= count_level ){  
       LOG(WARNING) << "process_key over max_level: '"<< max_level << "'";
+      LOG(ERROR) << "process_key over max_level: '"<< max_level << "'";
       count_level=0;
       return False;
     }
+	count_level++;
     bool result= t.ProcessKey(key) ;
     count_level=0 ; 
     return result; 

--- a/src/types.cc
+++ b/src/types.cc
@@ -808,6 +808,24 @@ namespace LogReg {
   }
 }
 
+namespace RimeApiReg{
+  string get_shared_data_dir() { return string( RimeGetSharedDataDir() ); }  
+  string get_user_data_dir()   { return string( RimeGetUserDataDir() );  }
+  string get_sync_dir()   { return string( RimeGetSyncDir() ); }
+  static const luaL_Reg funcs[]= {
+    {"get_shared_data_dir", WRAP( get_shared_data_dir)}, // RIME_API const char* RimeGetSharedDataDir();
+    {"get_user_data_dir",  WRAP( get_user_data_dir) }, //RIME_API const char* RimeGetUserDataDir();
+    {"get_sync_dir",  WRAP( get_sync_dir) },  //RIME_API const char* RimeGetSyncDir();
+    { NULL, NULL },
+  };
+  void init(lua_State *L) {
+    lua_createtable(L,0,0);
+    luaL_setfuncs(L, funcs, 0);
+    lua_setglobal(L, "rime_api");
+  }
+}
+
+
 //--- Lua
 #define EXPORT(ns, L) \
   do { \
@@ -854,4 +872,5 @@ void types_init(lua_State *L) {
   EXPORT(KeyEventNotifierReg, L);
   EXPORT(ConnectionReg, L);
   LogReg::init(L);
+  RimeApiReg::init(L);
 }

--- a/src/types.cc
+++ b/src/types.cc
@@ -402,12 +402,14 @@ namespace EngineReg {
       LOG(ERROR) << "error parsing input: '" << repr << "'";
       return False;
     }
-    if ( count_level++ >= max_level ){
+    if ( max_level <= count_level++ ){
       LOG(ERROR) << "process_key over max_level: '"<< max_level << "'";
       count_level=0;
-      return True ;
+      return False;
     }
-    return t.ProcessKey(key); 
+    bool result= t.ProcessKey(key) ;
+    count_level=0 ; 
+    return result; 
   }
 
   bool process_keys( T &t, string key_sequence){

--- a/src/types.cc
+++ b/src/types.cc
@@ -384,7 +384,7 @@ namespace KeyEventReg {
 }
 
 namespace EngineReg {
-#define MAX_LEVEL=30
+#define MAX_LEVEL 30
   typedef Engine T;
   static int max_level=MAX_LEVEL;
   static int count_level=0;

--- a/src/types.cc
+++ b/src/types.cc
@@ -243,26 +243,6 @@ namespace TranslationReg {
   };
 }
 
-namespace TableTranslatorReg {
-  typedef ScriptTranslator T;
-  //typedef ConfigValue T;
-
-  static const luaL_Reg funcs[] = {
-    { NULL, NULL },
-  };
-
-  static const luaL_Reg methods[] = {
-    { NULL, NULL },
-  };
-
-  static const luaL_Reg vars_get[] = {
-    { NULL, NULL },
-  };
-
-  static const luaL_Reg vars_set[] = {
-    { NULL, NULL },
-  };
-}
 
 namespace ReverseDbReg {
   typedef ReverseDb T;
@@ -988,7 +968,6 @@ void types_init(lua_State *L) {
   EXPORT(SegmentReg, L);
   EXPORT(CandidateReg, L);
   EXPORT(TranslationReg, L);
-  EXPORT(TableTranslatorReg, L);
   EXPORT(ReverseDbReg, L);
   EXPORT(SegmentationReg, L);
   EXPORT(MenuReg, L);

--- a/src/types.cc
+++ b/src/types.cc
@@ -283,12 +283,16 @@ namespace SegmentationReg {
     t.Reset(length);
   }
 
+  bool empty(T &t){
+	  return t.empty();
+  }
+
   static const luaL_Reg funcs[] = {
     { NULL, NULL },
   };
 
   static const luaL_Reg methods[] = {
-    { "empty", WRAPMEM(T::empty) },
+    { "empty", WRAP(empty) },
     { "back", WRAP(back) },
     { "pop_back", WRAP(pop_back) },
     { "reset_length", WRAP(reset_length) },
@@ -525,12 +529,16 @@ namespace CompositionReg {
     t.pop_back();
   }
 
+  bool empty(T &t){
+	  return t.empty();
+  }
+
   static const luaL_Reg funcs[] = {
     { NULL, NULL },
   };
 
   static const luaL_Reg methods[] = {
-    { "empty", WRAPMEM(T::empty) },
+    { "empty", WRAP(empty) },
     { "back", WRAP(back) },
     { "pop_back", WRAP(pop_back) },
     { "push_back", WRAP(push_back) },

--- a/src/types.cc
+++ b/src/types.cc
@@ -385,46 +385,41 @@ namespace KeyEventReg {
 }
 
 namespace EngineReg {
-#define MAX_LEVEL 1
   typedef Engine T;
-  static int max_level=MAX_LEVEL;
-  static int count_level=0;
-  int get_count_level(T &t) {
-    return count_level;
-  }
-  int get_max_level(T &t) {
-    return max_level;
-  }
-  void set_max_level(T &t, int num) {
-    max_level=  (num <= 1 ) ? 1 :  num ;
-	max_level= (max_level > MAX_LEVEL) ? MAX_LEVEL : max_level;
-  }
-  
-  bool process_key( T &t, string  repr ) {
-    KeyEvent key;
-    if (!key.Parse(repr)) {
-      LOG(ERROR) << "error parsing input: '" << repr << "'";
-      return False;
-    }
-    if ( max_level <= count_level ){  
-      LOG(WARNING) << "process_key over max_level: '"<< max_level << "'";
-      LOG(ERROR) << "process_key over max_level: '"<< max_level << "'";
-      count_level=0;
-      return False;
-    }
-	count_level++;
-    bool result= t.ProcessKey(key) ;
-    count_level=0 ; 
-    return result; 
-  }
 
-  bool process_keys( T &t, string key_sequence){
+  bool process_key( T &t, const KeyEvent &keyevent){ 
+	static unsigned int count_level=0;
+	/*
+    KeyEvent keyevent;
+    if (!keyevent.Parse(key) ) {
+      LOG(ERROR) << "error parsing input: '" << key<< "'";
+      return False;
+    }
+	*/
+	if (count_level >0 ) {
+		count_level=0;
+		return False ;
+	}
+	count_level++;
+    bool res= t.ProcessKey(keyevent) ;
+	count_level=0;
+    return res;
+  }
+  bool process_keys( T &t, const string &key_sequence){ 
+	static unsigned int count_level=0;
+	
     KeySequence keys;
     if (!keys.Parse(key_sequence) ) {
       LOG(ERROR) << "error parsing input: '" << key_sequence << "'";
       return False;
     }
-    for (const KeyEvent& key : keys)  t.ProcessKey(key);  
+	if (count_level >0 ) {
+		count_level=0;
+		return False ;
+	}
+	count_level++;
+    for (const KeyEvent& key : keys)  process_key(t,key) ;
+	count_level=0;
     return True;
   }
 
@@ -434,7 +429,6 @@ namespace EngineReg {
 
   static const luaL_Reg methods[] = {
     { "commit_text", WRAPMEM(T::CommitText) },
-    { "process_key", WRAP(process_key) },
     { "process_keys", WRAP(process_keys) },
     { NULL, NULL },
   };
@@ -443,14 +437,11 @@ namespace EngineReg {
     { "schema", WRAPMEM(T::schema) },
     { "context", WRAPMEM(T::context) },
     { "active_engine", WRAPMEM(T::active_engine) },
-    { "max_level", WRAP(get_max_level)},
-    { "count_level", WRAP(get_count_level)},
     { NULL, NULL },
   };
 
   static const luaL_Reg vars_set[] = {
     { "active_engine", WRAPMEM(T::set_active_engine) },
-    { "max_level", WRAP(set_max_level)},
     { NULL, NULL },
   };
 }

--- a/src/types.cc
+++ b/src/types.cc
@@ -6,6 +6,21 @@
 #include <rime/schema.h>
 #include <rime/config.h>
 #include <rime/gear/translator_commons.h>
+// test
+#include <rime/gear/echo_translator.h>
+#include <rime/gear/script_translator.h>
+#include <rime/gear/switch_translator.h>
+#include <boost/algorithm/string.hpp>
+#include <boost/range/adaptor/reversed.hpp>
+#include <rime/gear/schema_list_translator.h>
+#include <rime/dict/dictionary.h>
+#include <rime/dict/user_dictionary.h>
+#include <rime/gear/charset_filter.h>
+#include <rime/gear/poet.h>
+#include <rime/gear/table_translator.h>
+#include <rime/gear/translator_commons.h>
+#include <rime/gear/unity_table_encoder.h>
+// 
 #include <rime/dict/reverse_lookup_dictionary.h>
 #include <rime/key_event.h>
 #include <rime/switcher.h>
@@ -216,6 +231,27 @@ namespace TranslationReg {
 
   static const luaL_Reg methods[] = {
     { "iter", raw_iter },
+    { NULL, NULL },
+  };
+
+  static const luaL_Reg vars_get[] = {
+    { NULL, NULL },
+  };
+
+  static const luaL_Reg vars_set[] = {
+    { NULL, NULL },
+  };
+}
+
+namespace TableTranslatorReg {
+  typedef ScriptTranslator T;
+  //typedef ConfigValue T;
+
+  static const luaL_Reg funcs[] = {
+    { NULL, NULL },
+  };
+
+  static const luaL_Reg methods[] = {
     { NULL, NULL },
   };
 
@@ -952,6 +988,7 @@ void types_init(lua_State *L) {
   EXPORT(SegmentReg, L);
   EXPORT(CandidateReg, L);
   EXPORT(TranslationReg, L);
+  EXPORT(TableTranslatorReg, L);
   EXPORT(ReverseDbReg, L);
   EXPORT(SegmentationReg, L);
   EXPORT(MenuReg, L);

--- a/src/types.cc
+++ b/src/types.cc
@@ -40,10 +40,10 @@ namespace SegmentReg {
 
   string get_status(const T &t) {
     switch (t.status) {
-    case T::kVoid: return "kVoid";
-    case T::kGuess: return "kGuess";
-    case T::kSelected: return "kSelected";
-    case T::kConfirmed: return "kConfirmed";
+      case T::kVoid: return "kVoid";
+      case T::kGuess: return "kGuess";
+      case T::kSelected: return "kSelected";
+      case T::kConfirmed: return "kConfirmed";
     }
     return "";
   }
@@ -135,8 +135,8 @@ namespace CandidateReg {
   }
 
   an<T> make(const string type,
-                    size_t start, size_t end,
-                    const string text, const string comment)
+      size_t start, size_t end,
+      const string text, const string comment)
   {
     return New<SimpleCandidate>(type, start, end, text, comment);
   }
@@ -283,7 +283,7 @@ namespace SegmentationReg {
   }
 
   bool empty(T &t){
-	  return t.empty();
+    return t.empty();
   }
 
   static const luaL_Reg funcs[] = {
@@ -385,12 +385,27 @@ namespace KeyEventReg {
 
 namespace EngineReg {
   typedef Engine T;
-
+  static int max_level=30;
+  static int count_level=0;
+  int get_count_level(T &t) {
+    return count_level;
+  }
+  int get_max_level(T &t) {
+    return max_level;
+  }
+  void set_max_level(T &t, int num) {
+    max_level=  (num <= 1 ) ? 1 :  num ;
+  }
   bool process_key( T &t, string  repr ) {
     KeyEvent key;
     if (!key.Parse(repr)) {
       LOG(ERROR) << "error parsing input: '" << repr << "'";
       return False;
+    }
+    if ( count_level++ >= max_level ){
+      LOG(ERROR) << "process_key over max_level: '"<< max_level << "'";
+      count_level=0;
+      return True ;
     }
     return t.ProcessKey(key); 
   }
@@ -420,11 +435,14 @@ namespace EngineReg {
     { "schema", WRAPMEM(T::schema) },
     { "context", WRAPMEM(T::context) },
     { "active_engine", WRAPMEM(T::active_engine) },
+    { "max_level", WRAP(get_max_level)},
+    { "count_level", WRAP(get_count_level)},
     { NULL, NULL },
   };
 
   static const luaL_Reg vars_set[] = {
     { "active_engine", WRAPMEM(T::set_active_engine) },
+    { "max_level", WRAP(set_max_level)},
     { NULL, NULL },
   };
 }
@@ -550,7 +568,7 @@ namespace CompositionReg {
   }
 
   bool empty(T &t){
-	  return t.empty();
+    return t.empty();
   }
 
   static const luaL_Reg funcs[] = {
@@ -693,12 +711,12 @@ static int raw_connect(lua_State *L) {
 
   auto c = t.connect
     ([lua, o](I... i) {
-       auto r = lua->void_call<an<LuaObj>, Context *>(o, i...);
-       if (!r.ok()) {
-         auto e = r.get_err();
-         LOG(ERROR) << "Context::Notifier error(" << e.status << "): " << e.e;
-       }
-     });
+     auto r = lua->void_call<an<LuaObj>, Context *>(o, i...);
+     if (!r.ok()) {
+       auto e = r.get_err();
+       LOG(ERROR) << "Context::Notifier error(" << e.status << "): " << e.e;
+     }
+    });
 
   LuaType<boost::signals2::connection>::pushdata(L, c);
   return 1;
@@ -857,28 +875,28 @@ namespace RimeApiReg{
 //--- Lua
 #define EXPORT(ns, L) \
   do { \
-  export_type(L, LuaType<ns::T>::name(), LuaType<ns::T>::gc,       \
-              ns::funcs, ns::methods, ns::vars_get, ns::vars_set); \
-  export_type(L, LuaType<ns::T &>::name(), NULL,                   \
-              ns::funcs, ns::methods, ns::vars_get, ns::vars_set); \
-  export_type(L, LuaType<const ns::T>::name(), LuaType<ns::T>::gc, \
-              ns::funcs, ns::methods, ns::vars_get, ns::vars_set); \
-  export_type(L, LuaType<const ns::T &>::name(), NULL,             \
-              ns::funcs, ns::methods, ns::vars_get, ns::vars_set); \
-  export_type(L, LuaType<an<ns::T>>::name(), NULL,                 \
-              ns::funcs, ns::methods, ns::vars_get, ns::vars_set); \
-  export_type(L, LuaType<an<const ns::T>>::name(), NULL,           \
-              ns::funcs, ns::methods, ns::vars_get, ns::vars_set); \
-  export_type(L, LuaType<ns::T *>::name(), NULL,                   \
-              ns::funcs, ns::methods, ns::vars_get, ns::vars_set); \
-  export_type(L, LuaType<const ns::T *>::name(), NULL,             \
-              ns::funcs, ns::methods, ns::vars_get, ns::vars_set); \
+    export_type(L, LuaType<ns::T>::name(), LuaType<ns::T>::gc,       \
+        ns::funcs, ns::methods, ns::vars_get, ns::vars_set); \
+    export_type(L, LuaType<ns::T &>::name(), NULL,                   \
+        ns::funcs, ns::methods, ns::vars_get, ns::vars_set); \
+    export_type(L, LuaType<const ns::T>::name(), LuaType<ns::T>::gc, \
+        ns::funcs, ns::methods, ns::vars_get, ns::vars_set); \
+    export_type(L, LuaType<const ns::T &>::name(), NULL,             \
+        ns::funcs, ns::methods, ns::vars_get, ns::vars_set); \
+    export_type(L, LuaType<an<ns::T>>::name(), NULL,                 \
+        ns::funcs, ns::methods, ns::vars_get, ns::vars_set); \
+    export_type(L, LuaType<an<const ns::T>>::name(), NULL,           \
+        ns::funcs, ns::methods, ns::vars_get, ns::vars_set); \
+    export_type(L, LuaType<ns::T *>::name(), NULL,                   \
+        ns::funcs, ns::methods, ns::vars_get, ns::vars_set); \
+    export_type(L, LuaType<const ns::T *>::name(), NULL,             \
+        ns::funcs, ns::methods, ns::vars_get, ns::vars_set); \
   } while (0)
 
 void export_type(lua_State *L,
-                 const char *name, lua_CFunction gc,
-                 const luaL_Reg *funcs, const luaL_Reg *methods,
-                 const luaL_Reg *vars_get, const luaL_Reg *vars_set);
+    const char *name, lua_CFunction gc,
+    const luaL_Reg *funcs, const luaL_Reg *methods,
+    const luaL_Reg *vars_get, const luaL_Reg *vars_set);
 
 void types_init(lua_State *L) {
   EXPORT(SegmentReg, L);

--- a/src/types.cc
+++ b/src/types.cc
@@ -384,8 +384,9 @@ namespace KeyEventReg {
 }
 
 namespace EngineReg {
+#define MAX_LEVEL=30
   typedef Engine T;
-  static int max_level=30;
+  static int max_level=MAX_LEVEL;
   static int count_level=0;
   int get_count_level(T &t) {
     return count_level;
@@ -395,7 +396,9 @@ namespace EngineReg {
   }
   void set_max_level(T &t, int num) {
     max_level=  (num <= 1 ) ? 1 :  num ;
+	max_level= (max_level > MAX_LEVEL) ? MAX_LEVEL : max_level;
   }
+  
   bool process_key( T &t, string  repr ) {
     KeyEvent key;
     if (!key.Parse(repr)) {
@@ -403,7 +406,7 @@ namespace EngineReg {
       return False;
     }
     if ( max_level <= count_level++ ){
-      LOG(ERROR) << "process_key over max_level: '"<< max_level << "'";
+      LOG(WARNING) << "process_key over max_level: '"<< max_level << "'";
       count_level=0;
       return False;
     }

--- a/src/types.cc
+++ b/src/types.cc
@@ -1,4 +1,3 @@
-#include <rime/candidate.h>
 #include <rime/translation.h>
 #include <rime/segmentation.h>
 #include <rime/menu.h>
@@ -387,12 +386,33 @@ namespace KeyEventReg {
 namespace EngineReg {
   typedef Engine T;
 
+  bool process_key( T &t, string  repr ) {
+    KeyEvent key;
+    if (!key.Parse(repr)) {
+      LOG(ERROR) << "error parsing input: '" << repr << "'";
+      return False;
+    }
+    return t.ProcessKey(key); 
+  }
+
+  bool process_keys( T &t, string key_sequence){
+    KeySequence keys;
+    if (!keys.Parse(key_sequence) ) {
+      LOG(ERROR) << "error parsing input: '" << key_sequence << "'";
+      return False;
+    }
+    for (const KeyEvent& key : keys)  t.ProcessKey(key);  
+    return True;
+  }
+
   static const luaL_Reg funcs[] = {
     { NULL, NULL },
   };
 
   static const luaL_Reg methods[] = {
     { "commit_text", WRAPMEM(T::CommitText) },
+    { "process_key", WRAP(process_key) },
+    { "process_keys", WRAP(process_keys) },
     { NULL, NULL },
   };
 


### PR DESCRIPTION
EngineReg 新增 process_key()   & process_keys()  
1  移除 thread  
2 增加 巢狀層數限制  超出限制 將跳離
     max_level  （read/write)
     conut_level (read)
3  可 設定 engine.max_level   

lua examp
``` lua
local processor_func(key,env)
     local keycher=     key:modify ==0  and string.char( key.keycode) 
      ......
      if  keycher=="c" then    --  max_level  -- 預設層數 
             context.input:push(keycher) 
             env.engine:process_key("c")
      end 
      if keycher == "d"  and env.engine.count_level < 10 then  -- 用戶自行限制層數
            context.input:push(keycher)
            env.engine:process_key("d")
       end 
```



    
