### PR TITLE
Switch to rime API struct, instead of using raw functions

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -817,17 +817,36 @@ namespace LogReg {
 }
 
 namespace RimeApiReg{
-  string get_shared_data_dir() { return string( RimeGetSharedDataDir() ); }  
-  string get_user_data_dir()   { return string( RimeGetUserDataDir() );  }
-  string get_sync_dir()   { return string( RimeGetSyncDir() ); }
+  string get_rime_version() {
+    RimeApi* rime = rime_get_api();
+    return string(rime->get_version());
+  }
+
+  string get_shared_data_dir() {
+    RimeApi* rime = rime_get_api();
+    return string(rime->get_shared_data_dir());
+  }
+
+  string get_user_data_dir() {
+    RimeApi* rime = rime_get_api();
+    return string(rime->get_user_data_dir());
+  }
+
+  string get_sync_dir() {
+    RimeApi* rime = rime_get_api();
+    return string(rime->get_sync_dir());
+  }
+
   static const luaL_Reg funcs[]= {
-    {"get_shared_data_dir", WRAP( get_shared_data_dir)}, // RIME_API const char* RimeGetSharedDataDir();
-    {"get_user_data_dir",  WRAP( get_user_data_dir) }, //RIME_API const char* RimeGetUserDataDir();
-    {"get_sync_dir",  WRAP( get_sync_dir) },  //RIME_API const char* RimeGetSyncDir();
+    { "get_rime_version", WRAP(get_rime_version) },
+    { "get_shared_data_dir", WRAP(get_shared_data_dir) },
+    { "get_user_data_dir",  WRAP(get_user_data_dir) },
+    { "get_sync_dir",  WRAP(get_sync_dir) },
     { NULL, NULL },
   };
+
   void init(lua_State *L) {
-    lua_createtable(L,0,0);
+    lua_createtable(L, 0, 0);
     luaL_setfuncs(L, funcs, 0);
     lua_setglobal(L, "rime_api");
   }


### PR DESCRIPTION
The raw API functions are deprecated from rime v1.0. New added APIs' are only available in [API struct](https://github.com/rime/librime/blob/bcf811c37fed61ba9d5ee2317a36fccb78c3ddd4/src/rime_api.h#L368). For example, the raw function `RimeGetVersion` is not exposed in `rime_api.h`. The only way to call it is calling through the API struct:

```c++
RimeApi* rime = rime_get_api();
string ver = string(rime->get_version());
```

See: [Discuss about API](https://github.com/rime/librime/issues/175#issuecomment-366705077)