### PR TITLE
Export Rime::Switcher

### DIFF
--- a/sample/lua/switch.lua
+++ b/sample/lua/switch.lua
@@ -1,0 +1,84 @@
+--[[
+switch_processor: 通过选择自定义的候选项来切换开关（以简繁切换和下一方案为例）
+
+`Switcher` 适用于：
+1. 不方便或不倾向用 key_binder 处理的情况
+2. 自定义开关的读取（本例未体现）
+
+须将 lua_processor@switch_processor 放在 engine/processors 里，并位于默认 selector 之前
+
+为更好的使用本例，可以添加置顶的自定义词组，如
+〔简〕	simp
+〔繁〕	simp
+〔下一方案〕	next
+--]]
+
+-- 帮助函数，返回被选中的候选的索引
+local function select_index(key, env)
+  local ch = key.keycode
+  local index = -1
+  local select_keys = env.engine.schema.select_keys
+  if select_keys ~= nil and select_keys ~= "" and not key.ctrl() and ch >= 0x20 and ch < 0x7f then
+    local pos = string.find(select_keys, string.char(ch))
+    if pos ~= nil then index = pos end
+  elseif ch >= 0x30 and ch <= 0x39 then
+    index = (ch - 0x30 + 9) % 10
+  elseif ch >= 0xffb0 and ch < 0xffb9 then
+    index = (ch - 0xffb0 + 9) % 10
+  elseif ch == 0x20 then
+    index = 0
+  end
+  return index
+end
+
+-- 切换开关函数
+local function apply_switch(env, keyword, target_state)
+  local ctx = env.engine.context
+  local swt = env.switcher
+  local conf = swt.user_config
+  ctx:set_option(keyword, target_state)
+  -- 如果设置了自动保存，则需相应的配置
+  if swt:is_auto_save(keyword) and conf ~= nil then
+    conf:set_bool("var/option/" .. keyword, target_state)
+  end
+end
+
+local kRejected = 0
+local kAccepted = 1
+local kNoop = 2
+
+local function selector(key, env)
+  if env.switcher == nil then return kNoop end
+  if key:release() or key:alt() then return kNoop end
+  local idx = select_index(key,env)
+  if idx < 0 then return kNoop end
+  local ctx = env.engine.context
+  if ctx.input == "simp" then -- 当输入为 "simp" 时响应选择
+    local state = nil
+    if idx == 0 then
+      state = true
+    elseif idx == 1 then
+      state = false
+    end
+    if state ~= nil then
+      apply_switch(env, "simplification", state)
+      ctx:clear() -- 切换完成后清空，避免上屏
+      return kAccepted
+    end
+  elseif ctx.input == "next" and idx == 0 then
+    env.switcher:select_next_schema()
+    ctx:clear()
+    return kAccepted
+  end
+
+  return kNoop
+end
+
+-- 初始化 switcher
+local function init(env)
+  -- 若当前 librime-lua 版本未集成 Switcher 则无事发生
+  if Switcher == nil then return end
+  env.switcher = Switcher(env.engine)
+end
+
+return { init = init, func = selector }

--- a/sample/rime.lua
+++ b/sample/rime.lua
@@ -67,3 +67,9 @@ single_char_filter = require("single_char")
 -- reverse_lookup_filter: 依地球拼音为候选项加上带调拼音的注释
 -- 详见 `lua/reverse.lua`
 reverse_lookup_filter = require("reverse")
+
+-- III. processors:
+
+-- switch_processor: 通过选择自定义的候选项来切换开关（以简繁切换和下一方案为例）
+-- 详见 `lua/switch.lua`
+switch_processor = require("switch")

--- a/src/types.cc
+++ b/src/types.cc
@@ -10,7 +10,6 @@
 #include <rime/dict/reverse_lookup_dictionary.h>
 #include <rime/key_event.h>
 #include <rime/switcher.h>
-#include <rime/ticket.h>
 #include "lua_gears.h"
 #include "lib/lua_templates.h"
 
@@ -868,6 +867,7 @@ namespace SwitcherReg {
 
   static const luaL_Reg methods[] = {
     { "select_next_schema", WRAPMEM(T::SelectNextSchema) },
+    { "is_auto_save", WRAPMEM(T::IsAutoSave) },
     { "refresh_menu", WRAPMEM(T::RefreshMenu) },
     { "activate", WRAPMEM(T::Activate) },
     { "deactivate", WRAPMEM(T::Deactivate) },
@@ -875,7 +875,6 @@ namespace SwitcherReg {
   };
 
   static const luaL_Reg vars_get[] = {
-    { "is_auto_save", WRAPMEM(T::IsAutoSave) },
     { "attached_engine", WRAPMEM(T::attached_engine) },
     { "user_config", WRAPMEM(T::user_config) },
     { "active", WRAPMEM(T::active) },
@@ -932,6 +931,7 @@ void types_init(lua_State *L) {
   EXPORT(PropertyUpdateNotifierReg, L);
   EXPORT(KeyEventNotifierReg, L);
   EXPORT(ConnectionReg, L);
+  EXPORT(SwitcherReg, L);
   LogReg::init(L);
   RimeApiReg::init(L);
 }

--- a/src/types.cc
+++ b/src/types.cc
@@ -9,6 +9,7 @@
 #include <rime/gear/translator_commons.h>
 #include <rime/dict/reverse_lookup_dictionary.h>
 #include <rime/key_event.h>
+#include <rime/switcher.h>
 #include "lua_gears.h"
 #include "lib/lua_templates.h"
 
@@ -816,7 +817,7 @@ namespace LogReg {
   }
 }
 
-namespace RimeApiReg{
+namespace RimeApiReg {
   string get_rime_version() {
     RimeApi* rime = rime_get_api();
     return string(rime->get_version());
@@ -852,6 +853,38 @@ namespace RimeApiReg{
   }
 }
 
+namespace SwitcherReg {
+  typedef Switcher T;
+
+  an<T> make(const Engine *engine) {
+    return New<T>(engine);
+  }
+
+  static const luaL_Reg funcs[] = {
+    { "Switcher", WRAP(make) },
+    { NULL, NULL },
+  };
+
+  static const luaL_Reg methods[] = {
+    { "select_next_schema", WRAPMEM(T::SelectNextSchema) },
+    { "refresh_menu", WRAPMEM(T::RefreshMenu) },
+    { "activate", WRAPMEM(T::Activate) },
+    { "deactivate", WRAPMEM(T::Deactivate) },
+    { NULL, NULL },
+  };
+
+  static const luaL_Reg vars_get[] = {
+    { "is_auto_save", WRAPMEM(T::IsAutoSave) },
+    { "attached_engine", WRAPMEM(T::attached_engine) },
+    { "user_config", WRAPMEM(T::user_config) },
+    { "active", WRAPMEM(T::active) },
+    { NULL, NULL },
+  };
+
+  static const luaL_Reg vars_set[] = {
+    { NULL, NULL },
+  };
+}
 
 //--- Lua
 #define EXPORT(ns, L) \

--- a/src/types.cc
+++ b/src/types.cc
@@ -10,6 +10,7 @@
 #include <rime/dict/reverse_lookup_dictionary.h>
 #include <rime/key_event.h>
 #include <rime/switcher.h>
+#include <rime/ticket.h>
 #include "lua_gears.h"
 #include "lib/lua_templates.h"
 

--- a/src/types.cc
+++ b/src/types.cc
@@ -857,7 +857,7 @@ namespace RimeApiReg {
 namespace SwitcherReg {
   typedef Switcher T;
 
-  an<T> make(const Engine *engine) {
+  an<T> make(Engine *engine) {
     return New<T>(engine);
   }
 


### PR DESCRIPTION
This change export `Rime::Switcher` to Lua, so that users can directly manipulate it in a `lua_processor`.

My situation is to toggle a switch through selecting candidates, instead of key bindings. Following is partial of the `processor`'s code:

```Lua
local function processor(key, env)
  local context = env.engine.context
  local switcher = Switcher(env.engine)
  local user_config = switcher.user_config

  -- get option_name and some_bool_value

  if --[[ some condition --]] then
    context:set_option(option_name, some_bool_value)
    if switcher:is_auto_save(option_name) then
      user_config:set_bool("var/option/" .. option_name, some_bool_value)
    end
    context:clear()
    return kAccepted
  end
end
```