### PR TITLE
add  EngineReg select_schema()  env.engine:select( string schema_id )…

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -388,12 +388,24 @@ namespace KeyEventReg {
 namespace EngineReg {
   typedef Engine T;
 
+  static void select_schema(Engine* engine, const string& schema) {
+    if (!engine)
+      return;
+    if (schema == ".next") {
+      Switcher switcher(engine);
+      switcher.SelectNextSchema();
+    }
+    else {
+      engine->ApplySchema(new Schema(schema));
+    }
+  }
   static const luaL_Reg funcs[] = {
     { NULL, NULL },
   };
 
   static const luaL_Reg methods[] = {
     { "commit_text", WRAPMEM(T::CommitText) },
+    { "select_schema", WRAP(select_schema) },
     { NULL, NULL },
   };
 
@@ -859,6 +871,7 @@ namespace SwitcherReg {
   an<T> make(Engine *engine) {
     return New<T>(engine);
   }
+
 
   static const luaL_Reg funcs[] = {
     { "Switcher", WRAP(make) },

--- a/src/types.cc
+++ b/src/types.cc
@@ -38,7 +38,7 @@ namespace SegmentReg {
 
   T make(int start_pos, int end_pos) {
     return Segment(start_pos, end_pos);
-  }
+  };
 
   string get_status(const T &t) {
     switch (t.status) {
@@ -388,16 +388,8 @@ namespace KeyEventReg {
 namespace EngineReg {
   typedef Engine T;
 
-  static void select_schema(Engine* engine, const string& schema) {
-    if (!engine)
-      return;
-    if (schema == ".next") {
-      Switcher switcher(engine);
-      switcher.SelectNextSchema();
-    }
-    else {
-      engine->ApplySchema(new Schema(schema));
-    }
+  static void apply_schema(T *engine, Schema &schema){
+    engine->ApplySchema( &schema);
   }
   static const luaL_Reg funcs[] = {
     { NULL, NULL },
@@ -405,7 +397,7 @@ namespace EngineReg {
 
   static const luaL_Reg methods[] = {
     { "commit_text", WRAPMEM(T::CommitText) },
-    { "select_schema", WRAP(select_schema) },
+    { "apply_schema", WRAP(apply_schema) },
     { NULL, NULL },
   };
 
@@ -573,7 +565,12 @@ namespace CompositionReg {
 namespace SchemaReg {
   typedef Schema T;
 
+  an<T> make(const string &schema_id){
+    return New<T>(schema_id ) ;
+  };
+
   static const luaL_Reg funcs[] = {
+    { "Schema", WRAP(make) },
     { NULL, NULL },
   };
 


### PR DESCRIPTION
copy from  key_binder.cc

```lua
env.engine:select_schema("cangjit5")
env.engine.select_schema(".next")  



```


… .next

Signed-off-by: shewer <shewer@gmail.com>