### PR TITLE
 改善 複合鍵  字串比較   -> Control+Shift+4    key:repr() => Shift+Control+4

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -356,8 +356,13 @@ namespace KeyEventReg {
   int modifier(const T &t) {
     return t.modifier();
   }
+  
+  an<T> make(const string &key) {
+    return New<T>(key) ;
+  }
 
   static const luaL_Reg funcs[] = {
+    { "KeyEvent", WRAP(make)  },
     { NULL, NULL },
   };
 


### PR DESCRIPTION
Signed-off-by: shewer <shewer@gmail.com>
且 完善   key:eq( KeyEvent)

```lua
hot_key= KeyEvent("Control+Shift+4")
hot_key:repr() --      "Shift+Control+4"


if key:eq( hot_key) then 
   -- .......    
end 

```