### PR TITLE
Dev08.2 ConfigMap 增加 :keys() return table(array)  ConfigItem :to_obj() 

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -815,6 +815,7 @@ namespace ConfigMapReg {
     {"has_key", WRAPMEM(T::HasKey)},
     {"clear", WRAPMEM(T::Clear)},
     {"empty", WRAPMEM(T::empty)},
+    {"keys", raw_keys},
     { NULL, NULL },
   };
 
@@ -822,7 +823,6 @@ namespace ConfigMapReg {
     {"size", WRAP(size)},
     {"type",WRAP(type)},
     {"element",WRAP(element)},
-    {"keys", raw_keys},
   };
 
   static const luaL_Reg vars_set[] = {

--- a/src/types.cc
+++ b/src/types.cc
@@ -895,7 +895,6 @@ namespace ConfigItemReg {
     {"get_list",WRAP(get_list)},
     {"get_map",WRAP(get_map)},
     {"to_obj",raw_to_obj},
-
     { NULL, NULL },
   };
 
@@ -1004,7 +1003,6 @@ namespace ConfigReg {
   bool set_map(T &t, const string &path, an<ConfigMap> value) {
     return t.SetItem(path, value);
   }
-
 
   static const luaL_Reg funcs[] = {
     { NULL, NULL },

--- a/src/types.cc
+++ b/src/types.cc
@@ -862,30 +862,6 @@ namespace ConfigItemReg {
 #undef GET_
 //END_GET_
 
-  int raw_to_obj(lua_State *L) {
-    int n = lua_gettop(L);
-    if ( n < 1 ) return 0 ;
-
-    an<T> t_ptr = LuaType<an<T>>::todata(L,1);
-
-    switch(t_ptr->type()) {
-      case T::kScalar:
-        LuaType<lua_CFunction>::pushdata(L,  WRAP(get_value) );
-        break;
-      case T::kList:
-        LuaType<lua_CFunction>::pushdata(L,  WRAP(get_list) );
-        break;
-      case T::kMap:
-        LuaType<lua_CFunction>::pushdata(L,  WRAP(get_map) );
-        break;
-      default:
-        return 1;  // return self  ConfigItem
-    }
-    lua_insert(L,1);
-    if (lua_pcall(L, 1, 1, 0) != 0)  return 0;
-    return 1;
-  }
-
   static const luaL_Reg funcs[] = {
     { NULL, NULL },
   };
@@ -894,7 +870,6 @@ namespace ConfigItemReg {
     {"get_value",WRAP(get_value)},
     {"get_list",WRAP(get_list)},
     {"get_map",WRAP(get_map)},
-    {"to_obj",raw_to_obj},
     { NULL, NULL },
   };
 


### PR DESCRIPTION
ConfigMap 增加 keys()  return  table(array of keys (string)) 
ConfigItem 增加 to_obj() 自動轉換 ConfigValue or ConfigList or ConfigMap

```lua
local  config_map= config:get_item("translator"):to_obj() 
for key in next, config_map:keys() do 
        local tp= cfg_map:get(k):to_obj()
        print( k, tp.type,   tp.value  )
end
--[[   print out  text
closing_tips                      kScalar 【鯨舞倉】詞
comment_format                 kList   nil
dictionary                         kScalar whale_ext
disable_user_dict_for_patterns  kList   nil
enable_charset_filter                kScalar true
enable_completion                 kScalar true
enable_encoder           kScalar false
enable_sentence          kScalar false
enable_user_dict          kScalar false
initial_quality                kScalar 1.2
preedit_format              kList   nil
prism                            kScalar whaleliu_ext
suffix                             kScalar '
tips                               kScalar 【鯨舞倉】詞
--]]       

```