### PR TITLE
alternative fix to #134

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -403,8 +403,8 @@ namespace KeyEventReg {
 namespace EngineReg {
   typedef Engine T;
 
-  static void apply_schema(T *engine, Schema &schema) {
-    engine->ApplySchema(&schema);
+  static void apply_schema(T *engine, the<Schema> &schema) {
+    engine->ApplySchema(schema.release());
   }
 
   static const luaL_Reg funcs[] = {
@@ -588,8 +588,8 @@ namespace CompositionReg {
 namespace SchemaReg {
   typedef Schema T;
 
-  an<T> make(const string &schema_id){
-    return New<T>(schema_id ) ;
+  the<T> make(const string &schema_id) {
+    return std::unique_ptr<T>(new T(schema_id));
   };
 
   static const luaL_Reg funcs[] = {
@@ -1649,4 +1649,7 @@ void types_init(lua_State *L) {
   EXPORT(SwitcherReg, L);
   LogReg::init(L);
   RimeApiReg::init(L);
+
+  export_type(L, LuaType<the<SchemaReg::T>>::name(), LuaType<the<SchemaReg::T>>::gc,
+              SchemaReg::funcs, SchemaReg::methods, SchemaReg::vars_get, SchemaReg::vars_set);
 }


### PR DESCRIPTION
#134 指出了 Schema 被 GC 的问题，但 pr 没有针对根本原因作修复。

根本原因是 lua 并不了解 `apply_schema()` 会获取 Schema ownership，在调用结束后，以为 Schema 已经无处使用，所以自动回收了内存。

本 pr 为 lua wrapper 增加了 `unique_ptr<T>` （在 rime 中也记为 `the<T>`）类型的支持，并使用 `unique_ptr` 标记 `apply_schema()`，使 GC 不会错误回收已被apply的 Schema。

@shewer 请帮忙测一下是否奏效。