### PR TITLE
Dev084  add env.component env.klass   component@klass@name_space component@klass (name_space same as klass)

### DIFF
--- a/src/lua_gears.cc
+++ b/src/lua_gears.cc
@@ -28,12 +28,17 @@ static void raw_init(lua_State *L, const Ticket &t,
   Engine *e = t.engine;
   LuaType<Engine *>::pushdata(L, e);
   lua_setfield(L, -2, "engine");
-  LuaType<const string &>::pushdata(L, t.name_space);
+  LuaType<const string &>::pushdata(L,  t.klass );
+  lua_setfield(L, -2, "component");
+  Ticket t_m_ns(t.engine, t.name_space, t.name_space);
+  LuaType<const string &>::pushdata(L,  t_m_ns.klass );
+  lua_setfield(L, -2, "klass");
+  LuaType<const string &>::pushdata(L, t_m_ns.name_space);
   lua_setfield(L, -2, "name_space");
   *env = LuaObj::todata(L, -1);
   lua_pop(L, 1);
 
-  lua_getglobal(L, t.klass.c_str());
+  lua_getglobal(L, t_m_ns.klass.c_str());
   if (lua_type(L, -1) == LUA_TTABLE) {
     lua_getfield(L, -1, "init");
     if (lua_type(L, -1) == LUA_TFUNCTION) {
@@ -41,7 +46,7 @@ static void raw_init(lua_State *L, const Ticket &t,
       int status = lua_pcall(L, 1, 1, 0);
       if (status != LUA_OK) {
         const char *e = lua_tostring(L, -1);
-        LOG(ERROR) << "Lua Compoment of " << t.name_space << " initialize  error:(" << status << "): " << e;
+        LOG(ERROR) << "Lua Compoment of " << t.klass << "@" << t.name_space << " initialize  error:(" << status << "): " << e;
       }
     }
     lua_pop(L, 1);

--- a/src/lua_gears.h
+++ b/src/lua_gears.h
@@ -112,8 +112,7 @@ private:
 public:
   LuaComponent(an<Lua> lua) : lua_(lua) {};
   T* Create(const Ticket &a) {
-    Ticket t(a.engine, a.name_space, a.name_space);
-    return new T(t, lua_.get());
+    return new T(a, lua_.get());
   }
 };
 

--- a/src/types.cc
+++ b/src/types.cc
@@ -1507,6 +1507,7 @@ namespace KeySequenceReg {
 
   static const luaL_Reg methods[] = {
     { "parse", WRAPMEM(T::Parse) },
+    { "repr", WRAPMEM(T::repr) },
     { "toKeyEvent", WRAP(toKeyEvent) },
     { NULL, NULL },
   };

--- a/src/types.cc
+++ b/src/types.cc
@@ -1492,8 +1492,8 @@ namespace PhraseReg {
 namespace KeySequenceReg {
   typedef KeySequence T;
 
-  an<T> make(const string str) {
-    return New<T>(str);
+  an<T> make() {
+    return New<T>();
   }
 
   vector<KeyEvent> toKeyEvent(T& t) {


### PR DESCRIPTION
如題   

LOG(ERROR)  ua_gears.cc:49] Lua Compoment of **lua_translator@m_test@n_test** initialize  error:(2):
## schema
```yaml
engine/translators:
   lua_translator@m_test@n_test   #    name_space = n_test   klass= m_test component=lua_translator
   lua_translator@m_test                 #    name_space = m_test   klass= m_test component=lua_translator
```
### module: m_test
```lua 
function m_test.init(env)

    print(">>>>>>   init  component: ",env.component, "klass :", env.klass,
"name_space",env.name_space," ---_G[" .. env.klass .. "] module type : ",_G[env.klass])

    print()
    print("-------------- Lua Component  initilize error ---------------")
    assert(false ,">>>> Lua Component  initilize error <<<<")
end
function m_test.fini(env)
end
function m_test.func(inp,seg,env)
end
```
### output 
```   
>>>>>>   init  component: 	lua_translator	klass :	m_test	name_space	n_test	 ---_G[m_test] module type : 	table: 0x5557f3bd0810

-------------- Lua Component  initilize error ---------------
E20211022 10:15:32.038830 3418609 lua_gears.cc:49] Lua Compoment of lua_translator@m_test@n_test initialize  error:(2): ./rime.lua:51: >>>> Lua Component  initilize error <<<<





>>>>>>   init  component: 	lua_translator	klass :	m_test	name_space	m_test	 ---_G[m_test] module type : 	table: 0x5557f3bd0810

-------------- Lua Component  initilize error ---------------
E20211022 10:15:32.039114 3418609 lua_gears.cc:49] Lua Compoment of lua_translator@m_test initialize  error:(2): ./rime.lua:51: >>>> Lua Component  initilize error <<<<
```