### PR TITLE
LuaMemory::Memorize runtime error

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -11,13 +11,14 @@
 #include <rime/gear/translator_commons.h>
 #include <rime/dict/reverse_lookup_dictionary.h>
 #include <rime/key_event.h>
+#include <rime/gear/memory.h>
+#include <rime/dict/dictionary.h>
+#include <rime/dict/user_dictionary.h>
 #include <rime/switcher.h>
 #include "lua_gears.h"
 #include "lib/lua_templates.h"
 #include <opencc/opencc.h>
-#include "lua_ext_gears.h"
 
-#define ENABLE_TYPES_EXT
 
 using namespace rime;
 
@@ -1642,9 +1643,6 @@ namespace OpenccReg{
   };
 }
 
-#ifdef ENABLE_TYPES_EXT
-#include "types_ext.inc"
-#endif
 
 //--- Lua
 #define EXPORT(ns, L) \
@@ -1706,9 +1704,6 @@ void types_init(lua_State *L) {
   EXPORT(OpenccReg, L);
   LogReg::init(L);
   RimeApiReg::init(L);
-#ifdef ENABLE_TYPES_EXT
-  EXPORT_TYPES_EXT(L);
-#endif
 
   export_type(L, LuaType<the<SchemaReg::T>>::name(), LuaType<the<SchemaReg::T>>::gc,
               SchemaReg::funcs, SchemaReg::methods, SchemaReg::vars_get, SchemaReg::vars_set);

--- a/src/types.cc
+++ b/src/types.cc
@@ -1199,10 +1199,14 @@ namespace CommitEntryReg {
 
   static const luaL_Reg methods[] = {
     {"get",WRAP(get)},
+    //{"empty",WRAPMEM(T::empty)},
+    //{"clear",WRAPMEM(T::Clear)},
+    //{"append_phrase",WRAPMEM(T::AppendPhrase)},
     { NULL, NULL },
   };
 
   static const luaL_Reg vars_get[] = {
+    {"elements", WRAPMEM_GET(T::elements)},
     { NULL, NULL },
   };
 

--- a/src/types.cc
+++ b/src/types.cc
@@ -1199,14 +1199,10 @@ namespace CommitEntryReg {
 
   static const luaL_Reg methods[] = {
     {"get",WRAP(get)},
-    //{"empty",WRAPMEM(T::empty)},
-    //{"clear",WRAPMEM(T::Clear)},
-    //{"append_phrase",WRAPMEM(T::AppendPhrase)},
     { NULL, NULL },
   };
 
   static const luaL_Reg vars_get[] = {
-    {"elements", WRAPMEM_GET(T::elements)},
     { NULL, NULL },
   };
 

--- a/src/types.cc
+++ b/src/types.cc
@@ -1189,7 +1189,7 @@ namespace LogReg {
 namespace CommitEntryReg {
   typedef CommitEntry T;
 
-  vector<const rime::DictEntry*> get(T& ce) {
+  vector<const rime::DictEntry*> get(const T& ce) {
     return ce.elements;
   }
 


### PR DESCRIPTION
當 luamemory 觸發 Memorize(const CommitEntry) 時
 call  CommitEntryReg::get(T &t) 將造成 runtime error 
 
己在本地端修正,可正常運行