### PR TITLE
fixid:  refer to wrong  Segment , when Segmention is empty

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -295,7 +295,9 @@ namespace ReverseDbReg {
 namespace SegmentationReg {
   typedef Segmentation T;
 
-  Segment &back(T &t) {
+  optional<Segment &> back(T &t) {
+    if (t.empty())
+      return {};
     return t.back();
   }
 
@@ -566,7 +568,9 @@ namespace CompositionReg {
     return dynamic_cast<Segmentation *>(&t);
   }
 
-  Segment &back(T &t) {
+  optional<Segment &> back(T &t) {
+    if (t.empty())
+      return {};
     return t.back();
   }
 


### PR DESCRIPTION
在 composition  , segmentation  empty時,用back()  取出的segment 將無法操作且會造成 segmentation fault (core dumped)