### PR TITLE
add TranslationReg  vars_get exhausted

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -248,6 +248,7 @@ namespace TranslationReg {
   };
 
   static const luaL_Reg vars_get[] = {
+    { "exhausted", WRAPMEM(T, exhausted) },
     { NULL, NULL },
   };
 


### PR DESCRIPTION
'''lua
tran = Translation(
    function() 
         for i=1,5 do
              yield( Candidate('test',0,2,'test' .. i, i) )
         end 
      end)

for cand in tran:iter() do  print(tran.exhausted, cand.text ) end --[[ res
false   test1
false   test2
false   test3
false   test4
true    test5
--]]