### PR TITLE
add TranslationReg  methods transform  for instance of LuaTranslation

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -236,6 +236,20 @@ namespace TranslationReg {
     lua_pushvalue(L, 1);
     return 2;
   }
+  
+  // tran:transform(func,...) --> tran.transform(tran,func, ...)
+  // lua_call(L, n, 1); func(tran[,...])
+  int raw_transform(lua_State *L) {
+    int n = lua_gettop(L);
+    if ( 2 > n )
+      return 0;
+    
+    lua_pushcfunction(L, raw_make); // ...,raw_make
+    lua_rotate(L, 2, -1);  // tran, ... raw_make, func
+    lua_rotate(L, 1, 2);  // raw_make, func, tarn,...
+    lua_call(L, n, 1);
+    return 1;
+  }
 
   static const luaL_Reg funcs[] = {
     { "Translation", raw_make },
@@ -244,6 +258,7 @@ namespace TranslationReg {
 
   static const luaL_Reg methods[] = {
     { "iter", raw_iter },
+    { "transform", raw_transform },
     { NULL, NULL },
   };
 


### PR DESCRIPTION
ex:
```lua
local function select_quality(tarn, quality)
       for cand in tran:iter() do 
            if cand.quality > 1.5 then
                yield(cand)
             end
        end
 end

filter.func(inp,env,cands)  -- inp  : instance of Translation
  local tran = inp:transform( select_quality, 1.5)
  for cand in tran:iter() do 
           yield(cand)
    end
end
```