### PR TITLE
Projection reg dev

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -1066,6 +1066,13 @@ namespace ProjectionReg{
         //load from strings
         cl = New<ConfigList>();
         for (int i = 2; i<=n ; i++){
+          if (!lua_isstring(L,i)){
+            // fixed NULL will (core dumped) error.
+            LOG(ERROR) << "bad argument #" << i << " to'?' string expected";
+            lua_pop(L, n);
+            lua_pushboolean(L, false);
+            return 1;
+          }
           cl->Append(
               New<ConfigValue>( lua_tostring(L,i) ) );
         }


### PR DESCRIPTION
Projection : 增加參數型別， 可以直接 load() 
Projection( [an<ConfigList>| table of strings | args ... of strings] ) , return obj, bool
load() : 增加參數型別 ( [an<ConfigList>| table of strings | args ... of strings] ) , return bool

```lua
function test_projection()
  local data={}
  data.str1 = "xlit|123|一二三"
  data.str2 ="xform|一|十|"
  data.res = "十二三"
 
 data.cl=ConfigList()
  data.cl:append(ConfigValue(data.str1).element)
  data.cl:append(ConfigValue(data.str2).element)

  local proj1= Projection(data.cl)  --  an<ConfigList> 
  local proj2= Projection(data.str1,data.str2) -- args of strings
  local proj3= Projection({data.str1, data.str2}) -- table of strings
 
 local proj4= Projection()  -- 原方法
  proj4:load(data.cl)

  assert( proj1:apply('123', true) == "十二三")
  assert(proj2:apply('123', true) == "十二三")
  assert(proj3:apply('123', true) == "十二三")
  assert(proj4:apply('123', true) =="十二三")
end
```
