### PR TITLE
增加支持.luac后缀

### DIFF
--- a/src/modules.cc
+++ b/src/modules.cc
@@ -23,12 +23,20 @@ static void lua_init(lua_State *L) {
   types_init(L);
   lua_getglobal(L, "package");
   lua_pushfstring(L, "%s%slua%s?.lua;"
+                  "%s%slua%s?.luac;"
                   "%s%slua%s?%sinit.lua;"
+                  "%s%slua%s?%sinit.luac;"
                   "%s%slua%s?.lua;"
+                  "%s%slua%s?.luac;"
+                  "%s%slua%s?%sinit.luac;"
                   "%s%slua%s?%sinit.lua;",
                   user_dir.c_str(), LUA_DIRSEP, LUA_DIRSEP,
+                  user_dir.c_str(), LUA_DIRSEP, LUA_DIRSEP,
+                  user_dir.c_str(), LUA_DIRSEP, LUA_DIRSEP, LUA_DIRSEP,
                   user_dir.c_str(), LUA_DIRSEP, LUA_DIRSEP, LUA_DIRSEP,
                   shared_dir.c_str(), LUA_DIRSEP, LUA_DIRSEP,
+                  shared_dir.c_str(), LUA_DIRSEP, LUA_DIRSEP,
+                  shared_dir.c_str(), LUA_DIRSEP, LUA_DIRSEP, LUA_DIRSEP,
                   shared_dir.c_str(), LUA_DIRSEP, LUA_DIRSEP, LUA_DIRSEP);
   lua_getfield(L, -2, "path");
   lua_concat(L, 2);


### PR DESCRIPTION
增加支持.luac后缀模块加载，和原有.lua的后缀作区分识别，便于发布闭源插件或发布字节码插件