### PR TITLE
add method to determine type of LuaObj

### DIFF
--- a/src/lib/lua.cc
+++ b/src/lib/lua.cc
@@ -273,6 +273,10 @@ LuaObj::~LuaObj() {
   luaL_unref(L_, LUA_REGISTRYINDEX, id_);
 }
 
+int LuaObj::type() {
+  return lua_type(L_, -1);
+}
+
 void LuaObj::pushdata(lua_State *L, std::shared_ptr<LuaObj> &o) {
   lua_rawgeti(L, LUA_REGISTRYINDEX, o->id_);
 }

--- a/src/lib/lua.cc
+++ b/src/lib/lua.cc
@@ -267,14 +267,11 @@ std::shared_ptr<LuaObj> Lua::getglobal(const std::string &v) {
 LuaObj::LuaObj(lua_State *L, int i) : L_(L) {
   lua_pushvalue(L, i);
   id_ = luaL_ref(L, LUA_REGISTRYINDEX);
+  type_ = lua_type(L, i);
 }
 
 LuaObj::~LuaObj() {
   luaL_unref(L_, LUA_REGISTRYINDEX, id_);
-}
-
-int LuaObj::type() {
-  return lua_type(L_, -1);
 }
 
 void LuaObj::pushdata(lua_State *L, std::shared_ptr<LuaObj> &o) {

--- a/src/lib/lua.h
+++ b/src/lib/lua.h
@@ -14,6 +14,7 @@ public:
 
   static void pushdata(lua_State *L, std::shared_ptr<LuaObj> &o);
   static std::shared_ptr<LuaObj> todata(lua_State *L, int i);
+  int type();
 
 private:
   LuaObj(lua_State *L, int i);

--- a/src/lib/lua.h
+++ b/src/lib/lua.h
@@ -14,11 +14,12 @@ public:
 
   static void pushdata(lua_State *L, std::shared_ptr<LuaObj> &o);
   static std::shared_ptr<LuaObj> todata(lua_State *L, int i);
-  int type();
+  int type() { return type_; }
 
 private:
   LuaObj(lua_State *L, int i);
   lua_State *L_;
+  int type_;
   int id_;
 };
 


### PR DESCRIPTION
fix #281 by adding member function ` int LuaObj::type() `

tested by add line in raw_init, return 6 
```cpp
LOG(INFO) << "(*func)->type() is " << (*func)->type();
```