### PR TITLE
CommitEntry add update(commit) update(entry, commit, prefix_str)

### DIFF
--- a/sample/lua/expand_translator.lua
+++ b/sample/lua/expand_translator.lua
@@ -28,11 +28,20 @@ local function memoryCallback(memory, commit)
 	return true
 end
 
+local function memoryCallback1(commit)
+  for i, dictentry in ipairs(commit:get()) do
+    commits:update_entry(dictentry, 1, "")
+  end
+  --commits:update(1) --
+end
+
+
 local function init(env)
   env.mem = Memory(env.engine,env.engine.schema)  --  ns= "translator"
   -- env.mem = Memory(env.engine,env.engine.schema, env.name_space )  
   -- env.mem = Memory(env.engine,Schema("cangjie5") ) --  ns= "translator- 
-  env.mem:memorize(function(commit) memoryCallback(env.mem, commit) end)
+  --env.mem:memorize(function(commit) memoryCallback(env.mem, commit) end)
+  env.mem:memorize(memoryCallback1)
   -- or use
   -- schema = Schema("cangjie5") -- schema_id
   -- env.mem = Memory(env.engine, schema, "translator")

--- a/src/types.cc
+++ b/src/types.cc
@@ -20,12 +20,11 @@
 #include <boost/regex.hpp>
 
 #include "lib/lua_export_type.h"
-#include "lib/luatype_boost_optional.h"
+#include "optional.h"
 
 #define ENABLE_TYPES_EXT
 
 using namespace rime;
-using boost::optional;
 
 namespace {
 


### PR DESCRIPTION
struct CommitEntry 已有 Memory* 可以直接 update_entry 

https://github.com/rime/librime/blob/cde8c2123c939417f45a4945e5439ea5cf9cee16/src/rime/gear/memory.cc#L105
https://github.com/rime/librime/blob/cde8c2123c939417f45a4945e5439ea5cf9cee16/src/rime/gear/memory.cc#L40-L46

DictEntry()   增加拷背機制   DictEntry( dictentry)  commit_entry 內的 dictentry 為 coost  DictEntry