### PR TITLE
follow up librime#806, avoid path-string conversion

### DIFF
--- a/src/modules.cc
+++ b/src/modules.cc
@@ -1,7 +1,7 @@
 #include <cstdio>
 #include <rime/common.h>
 #include <rime/registry.h>
-#include <rime_api.h>
+#include <rime/service.h>
 #include "lib/lua_templates.h"
 #include "lua_gears.h"
 
@@ -17,8 +17,11 @@ static bool file_exists(const char *fname) noexcept {
 }
 
 static void lua_init(lua_State *L) {
-  const auto user_dir = std::string(RimeGetUserDataDir());
-  const auto shared_dir = std::string(RimeGetSharedDataDir());
+  // path::string() returns native encoding on Windows
+  const auto user_dir =
+      rime::Service::instance().deployer().user_data_dir.string();
+  const auto shared_dir =
+      rime::Service::instance().deployer().shared_data_dir.string();
 
   types_init(L);
   lua_getglobal(L, "package");

--- a/src/opencc.cc
+++ b/src/opencc.cc
@@ -29,7 +29,7 @@ namespace {
 class Opencc {
 public:
   //static shared_ptr<Opencc> create(const path &config_path);
-  Opencc(const path& config_path);
+  Opencc(const string& utf8_config_path);
   bool ConvertWord(const string& text, vector<string>* forms);
   bool RandomConvertText(const string& text, string* simplified);
   bool ConvertText(const string& text, string* simplified);
@@ -43,10 +43,10 @@ private:
   opencc::DictPtr dict_;
 };
 
-Opencc::Opencc(const path& config_path) {
+Opencc::Opencc(const string& utf8_config_path) {
   opencc::Config config;
   // OpenCC accepts UTF-8 encoded path.
-  converter_ = config.NewFromFile(config_path.u8string());
+  converter_ = config.NewFromFile(utf8_config_path);
   const list<opencc::ConversionPtr> conversions =
     converter_->GetConversionChain()->GetConversions();
   dict_ = conversions.front()->GetDict();
@@ -116,23 +116,49 @@ vector<string> Opencc::convert_word(const string& text){
 namespace OpenccReg {
   using T = Opencc;
 
-  optional<T> make(const string &filename) {
-    path user_path = Service::instance().deployer().user_data_dir;
-    path shared_path = Service::instance().deployer().shared_data_dir;
-    try{
-      return T(user_path / "opencc" / filename);
-    }
-    catch(...) {
+  template<typename> using void_t = void;
+
+  template<typename U, typename = void>
+  struct COMPAT {
+    static optional<T> make(const string &filename) {
+      auto user_path = string(rime_get_api()->get_user_data_dir());
+      auto shared_path = string(rime_get_api()->get_shared_data_dir());
       try{
-        return T(shared_path / "opencc" / filename);
+        return T(user_path + "/opencc/" + filename);
       }
       catch(...) {
-        LOG(ERROR) << " [" << user_path << "|" << shared_path << "]/opencc/"
-          << filename  << ": File not found or InvalidFormat";
-        return {};
+        try{
+          return T(shared_path + "/opencc/" + filename);
+        }
+        catch(...) {
+          LOG(ERROR) << " [" << user_path << "|" << shared_path << "]/opencc/"
+                     << filename  << ": File not found or InvalidFormat";
+          return {};
+        }
       }
     }
-  }
+  };
+
+  template<typename U>
+  struct COMPAT<U, void_t<decltype(std::declval<U>().user_data_dir.string())>> {
+    static optional<T> make(const string &filename) {
+      path user_path = Service::instance().deployer().user_data_dir;
+      path shared_path = Service::instance().deployer().shared_data_dir;
+      try{
+        return T((user_path / "opencc" / filename).u8string());
+      }
+      catch(...) {
+        try{
+          return T((shared_path / "opencc" / filename).u8string());
+        }
+        catch(...) {
+          LOG(ERROR) << " [" << user_path << "|" << shared_path << "]/opencc/"
+                     << filename  << ": File not found or InvalidFormat";
+          return {};
+        }
+      }
+    }
+  };
 
   optional<vector<string>> convert_word(T &t,const string &s) {
     vector<string> res;
@@ -142,7 +168,7 @@ namespace OpenccReg {
   }
 
   static const luaL_Reg funcs[] = {
-    {"Opencc",WRAP(make)},
+    {"Opencc",WRAP(COMPAT<Deployer>::make)},
     { NULL, NULL },
   };
 

--- a/src/types.cc
+++ b/src/types.cc
@@ -1,3 +1,4 @@
+#include <rime_api.h>
 #include <rime/candidate.h>
 #include <rime/translation.h>
 #include <rime/segmentation.h>
@@ -15,9 +16,9 @@
 #include <rime/gear/memory.h>
 #include <rime/dict/dictionary.h>
 #include <rime/dict/user_dictionary.h>
+#include <rime/service.h>
 #include <rime/switcher.h>
 #include "lua_gears.h"
-#include <rime/service.h>
 #include <boost/regex.hpp>
 
 #include "lib/lua_export_type.h"
@@ -1845,43 +1846,35 @@ namespace KeySequenceReg {
 
 namespace RimeApiReg {
   string get_rime_version() {
-    RimeApi* rime = rime_get_api();
-    return string(rime->get_version());
+    return string(rime_get_api()->get_version());
   }
 
   string get_shared_data_dir() {
-    RimeApi* rime = rime_get_api();
-    return string(rime->get_shared_data_dir());
+    return Service::instance().deployer().shared_data_dir.string();
   }
 
   string get_user_data_dir() {
-    RimeApi* rime = rime_get_api();
-    return string(rime->get_user_data_dir());
+    return Service::instance().deployer().user_data_dir.string();
   }
 
   string get_sync_dir() {
-    RimeApi* rime = rime_get_api();
-    return string(rime->get_sync_dir());
+    return Service::instance().deployer().sync_dir.string();
   }
 
   string get_distribution_name(){
-    Deployer &deployer(Service::instance().deployer());
-    return deployer.distribution_name;
+    return Service::instance().deployer().distribution_name;
   }
 
   string get_distribution_code_name(){
-    Deployer &deployer(Service::instance().deployer());
-    return deployer.distribution_code_name;
+    return Service::instance().deployer().distribution_code_name;
   }
 
   string get_distribution_version(){
-    Deployer &deployer(Service::instance().deployer());
-    return deployer.distribution_version;
+    return Service::instance().deployer().distribution_version;
   }
 
   string get_user_id(){
-    Deployer &deployer(Service::instance().deployer());
-    return deployer.user_id;
+    return Service::instance().deployer().user_id;
   }
 
 // boost::regex api

--- a/src/types.cc
+++ b/src/types.cc
@@ -308,7 +308,8 @@ namespace ReverseDbReg {
   using T = ReverseDb;
 
   an<T> make(const string &file) {
-    an<T> db = New<ReverseDb>(string(RimeGetUserDataDir()) +  "/" + file);
+    an<T> db = New<ReverseDb>(
+        Service::instance().deployer().user_data_dir / file);
     db->Load();
     return db;
   }

--- a/src/types.cc
+++ b/src/types.cc
@@ -30,6 +30,47 @@ using namespace rime;
 
 namespace {
 
+template<typename> using void_t = void;
+
+template<typename T, typename = void>
+struct COMPAT {
+  // fallback version if librime is old
+  static an<ReverseDb> new_ReverseDb(const std::string &file) {
+    return New<ReverseDb>(std::string(RimeGetUserDataDir()) + "/" + file);
+  }
+
+  static string get_shared_data_dir() {
+    return string(rime_get_api()->get_shared_data_dir());
+  }
+
+  static string get_user_data_dir() {
+    return string(rime_get_api()->get_user_data_dir());
+  }
+
+  static string get_sync_dir() {
+    return string(rime_get_api()->get_sync_dir());
+  }
+};
+
+template<typename T>
+struct COMPAT<T, void_t<decltype(std::declval<T>().user_data_dir.string())>> {
+  static an<ReverseDb> new_ReverseDb(const std::string &file) {
+    return New<ReverseDb>(Service::instance().deployer().user_data_dir / file);
+  }
+
+  static string get_shared_data_dir() {
+    return Service::instance().deployer().shared_data_dir.string();
+  }
+
+  static string get_user_data_dir() {
+    return Service::instance().deployer().user_data_dir.string();
+  }
+
+  static string get_sync_dir() {
+    return Service::instance().deployer().sync_dir.string();
+  }
+};
+
 //--- wrappers for Segment
 namespace SegmentReg {
   using T = Segment;
@@ -309,8 +350,7 @@ namespace ReverseDbReg {
   using T = ReverseDb;
 
   an<T> make(const string &file) {
-    an<T> db = New<ReverseDb>(
-        Service::instance().deployer().user_data_dir / file);
+    an<T> db = COMPAT<Deployer>::new_ReverseDb(file);
     db->Load();
     return db;
   }
@@ -1849,18 +1889,6 @@ namespace RimeApiReg {
     return string(rime_get_api()->get_version());
   }
 
-  string get_shared_data_dir() {
-    return Service::instance().deployer().shared_data_dir.string();
-  }
-
-  string get_user_data_dir() {
-    return Service::instance().deployer().user_data_dir.string();
-  }
-
-  string get_sync_dir() {
-    return Service::instance().deployer().sync_dir.string();
-  }
-
   string get_distribution_name(){
     return Service::instance().deployer().distribution_name;
   }
@@ -1906,9 +1934,9 @@ namespace RimeApiReg {
 
   static const luaL_Reg funcs[]= {
     { "get_rime_version", WRAP(get_rime_version) },
-    { "get_shared_data_dir", WRAP(get_shared_data_dir) },
-    { "get_user_data_dir", WRAP(get_user_data_dir) },
-    { "get_sync_dir", WRAP(get_sync_dir) },
+    { "get_shared_data_dir", WRAP(COMPAT<Deployer>::get_shared_data_dir) },
+    { "get_user_data_dir", WRAP(COMPAT<Deployer>::get_user_data_dir) },
+    { "get_sync_dir", WRAP(COMPAT<Deployer>::get_sync_dir) },
     { "get_distribution_name", WRAP(get_distribution_name) },
     { "get_distribution_code_name", WRAP(get_distribution_code_name) },
     { "get_distribution_version", WRAP(get_distribution_version) },

--- a/src/types_ext.cc
+++ b/src/types_ext.cc
@@ -263,6 +263,11 @@ namespace UserDbReg{
     return {};
   }
 
+  string file_name(const T& t) {
+    // returns ANSI encoded string on Windows
+    return t.file_path().string();
+  }
+
   bool Open(T &t) { return t.Open(); }
   bool Close(T &t) { return t.Close(); }
   bool OpenReadOnly(T &t) { return t.OpenReadOnly(); }
@@ -300,7 +305,7 @@ namespace UserDbReg{
     {"read_only",WRAPMEM(T, readonly)},
     {"disabled",WRAPMEM(T, disabled)},
     {"name", WRAPMEM(T, name)},
-    {"file_name", WRAPMEM(T, file_name)},
+    {"file_name", WRAP(file_name)},
     { NULL, NULL },
   };
 

--- a/src/types_ext.cc
+++ b/src/types_ext.cc
@@ -38,6 +38,18 @@ struct COMPAT<T, void_t<decltype(std::declval<T>().name_space())>> {
   }
 };
 
+// fallback version of file_path() if librime is old
+template<typename> struct void_t1 { using t = int; };
+template<typename T, typename void_t1<decltype(std::declval<T>().file_name())>::t = 0>
+std::string get_UserDb_file_path_string(const T &t) {
+    return t.file_name();
+}
+
+template<typename T, typename void_t1<decltype(std::declval<T>().file_path())>::t = 0>
+std::string get_UserDb_file_path_string(const T &t) {
+    return t.file_path().string();
+}
+
 namespace ProcessorReg{
   using T = Processor;
 
@@ -305,7 +317,7 @@ namespace UserDbReg{
     {"read_only",WRAPMEM(T, readonly)},
     {"disabled",WRAPMEM(T, disabled)},
     {"name", WRAPMEM(T, name)},
-    {"file_name", WRAP(file_name)},
+    {"file_name", WRAP(get_UserDb_file_path_string<T>)},
     { NULL, NULL },
   };
 


### PR DESCRIPTION
Avoid using `RimeGet*Dir()` from `rime_api`. They return native path on Windows and coding conversion is incurred.

When passing path from lua to librime class, use either rime::path object or UTF-8 encoded string.