### PR TITLE
add SegmenReg    active_text(string)

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -104,6 +104,10 @@ namespace SegmentReg {
       t.status = T::kConfirmed;
   }
 
+  string active_text(T &t, const string &r) {
+    return r.substr(t.start, t.end - t.start);
+  }
+
   static const luaL_Reg funcs[] = {
     { "Segment", WRAP(make) },
     { NULL, NULL },
@@ -116,6 +120,7 @@ namespace SegmentReg {
     { "has_tag", WRAPMEM(T::HasTag) },
     { "get_candidate_at", WRAPMEM(T::GetCandidateAt) },
     { "get_selected_candidate", WRAPMEM(T::GetSelectedCandidate) },
+    { "active_text", WRAP(active_text) },
     { NULL, NULL },
   };
 


### PR DESCRIPTION
便於取得 substr   ,  減少  lua  string.sub  定位問題 
string.sub( inp,  seg._start+1 , seg._end )
```lua
function tran.func(inp, seg, env)
    local active_inp = seg:active_text(inp)
     ....
 end
```