### PR TITLE
Update types.cc

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -755,12 +755,14 @@ namespace ContextReg {
     { "select", WRAPMEM(T::Select) },
     { "confirm_current_selection", WRAPMEM(T::ConfirmCurrentSelection) },
     { "delete_current_selection", WRAPMEM(T::DeleteCurrentSelection) },
-    { "confirm_previous_selection", WRAPMEM(T::ConfirmPreviousSelection) },
+    { "confirm_previous_selection", WRAPMEM(T::ConfirmPreviousSelection) }, // deprecated
     { "reopen_previous_selection", WRAPMEM(T::ReopenPreviousSelection) },
     { "clear_previous_segment", WRAPMEM(T::ClearPreviousSegment) },
     { "reopen_previous_segment", WRAPMEM(T::ReopenPreviousSegment) },
     { "clear_non_confirmed_composition", WRAPMEM(T::ClearNonConfirmedComposition) },
     { "refresh_non_confirmed_composition", WRAPMEM(T::RefreshNonConfirmedComposition) },
+    { "begin_editing", WRAPMEM(T::BeginEditing) },
+    { "highlight", WRAPMEM(T::Highlight)}, // set candidate_selected without select_notifier
     { "set_option", WRAPMEM(T::set_option) },
     { "get_option", WRAPMEM(T::get_option) },
     { "set_property", WRAPMEM(T::set_property) },


### PR DESCRIPTION
update from librime context.h
```
commit 8b7f6b746b4f7790ade50f60c5d4b89488bc8f9d
Author: 居戎氏 <chen.sst@gmail.com>
Date:   Sat Mar 2 11:42:50 2024 +0800

    fix(context): tag selected segment after editing

    call Context::BeginEditing when input is edited after selection.
    move cursor also counts as edit.

    the tag is used to tell if BackSpace should delete the last input
    character or revert a recent selection.

    the information was previously denoted by kConfirmed status which caused
    the side-effect of breaking a user phrase into individual segments.

    fixed #746, fixed #830

commit 142902df0d21ce6dbd3a804ecdeee04752988c8c
Author: LEO Yoon-Tsaw <leoyoontsaw@icloud.com>
Date:   Fri Feb 9 11:38:00 2024 +0800

    feat(api): highlight_candidate*, change_page

    add function Context::Highlight

    Merges #620

```