### PR TITLE
migrate to rime_get_api

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -36,7 +36,7 @@ template<typename T, typename = void>
 struct COMPAT {
   // fallback version if librime is old
   static an<ReverseDb> new_ReverseDb(const std::string &file) {
-    return New<ReverseDb>(std::string(RimeGetUserDataDir()) + "/" + file);
+    return New<ReverseDb>(string(rime_get_api()->get_user_data_dir()) + "/" + file);
   }
 
   static string get_shared_data_dir() {


### PR DESCRIPTION
the deprecated librime 0.9 API function declarations will be move to a separeate header file rime_api_deprecated.h
in https://github.com/rime/librime/pull/877