### PR TITLE
added new function of SpansReg

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -2044,7 +2044,7 @@ namespace SpansReg {
   vector<size_t> get_vertices(const T &spans) {
     vector<size_t> res;
     size_t end = spans.end();
-    for (size_t stop =spans.start(); ; stop = spans.NextStop(stop)) {
+    for (size_t stop = spans.start(); ; stop = spans.NextStop(stop)) {
       if (spans.HasVertex(stop)) {
         res.push_back(stop);
       }


### PR DESCRIPTION
擴展 Spans 
```lua
-- return Spans 
cand:spans()
segment:spans()
composition:spans()

-- spans api 
spans:add_vertex( size_t vertex)  
spans:clear() --  vertices = {}
spans.vertices -- return **size_t** of  lua_table
spans.vertices = { 5, 4, 2 , "3 " ,4 }  -- vertices = { 2, 3, 4, 5}

```
