### PR TITLE
improve ConfigValue([value])  to support  lua_type(bool, string, number)

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -951,8 +951,22 @@ namespace ConfigValueReg {
   // an<T> make(){
   //  return New<T>();
   // };
-  an<T> make(string s){
-    return New<T>(s);
+
+  int raw_make(lua_State *L) {
+    an<T> t = New<T>();
+    if (lua_gettop(L) > 0 && !lua_isnil(L, 1)) {
+      if (lua_isstring(L, 1)) {
+        t->SetString(lua_tostring(L, 1));
+      }
+      else if(lua_isboolean(L, 1)){
+        t->SetBool(lua_toboolean(L, 1));
+      }
+      else {
+        LOG(WARNING) << "args #1 type error: " << luaL_typename(L, 1);
+      }
+    }
+    LuaType<an<T>>::pushdata(L, t);
+    return 1;
   };
 
   optional<bool> get_bool(T &t) {
@@ -1006,7 +1020,7 @@ namespace ConfigValueReg {
   }
 
   static const luaL_Reg funcs[] = {
-    {"ConfigValue", WRAP(make)},
+    {"ConfigValue",(raw_make)},
     { NULL, NULL },
   };
 


### PR DESCRIPTION
便於 ConfigValue(lua_datatype) 初使化
ConfigValue([nil]).value = ""
ConfigValue([table| userdata]).value = ""   with LOG(WARNING) 
ConfigValue(true).value = "true"
CanfigValue([number|string]).value = 等同 tostring(value) 
 ```lua
[0][./lua/selector.lua:33] → ConfigValue("aoeuao").value
"aoeuao"
[0][./lua/selector.lua:33] → ConfigValue(2).value
"2"
[0][./lua/selector.lua:33] → ConfigValue(2.33).value
"2.33"
[0][./lua/selector.lua:33] → ConfigValue(false).value
"false"
[0][./lua/selector.lua:33] → ConfigValue(true).value
"true"
[0][./lua/selector.lua:33] → ConfigValue(nil).value
""
[0][./lua/selector.lua:33] → ConfigValue().value
""
[0][./lua/selector.lua:33] → ConfigValue({}).value
W20241102 02:28:15.876928 129013982039616 types.cc:965] args #1 type error: table
""
```