### PR TITLE
add writable ShadowCandidate ( text, comment, preedit) 

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -328,7 +328,7 @@ namespace CandidateReg {
     { "get_dynamic_type", WRAP(dynamic_type) },
     { "get_genuine", WRAP(T::GetGenuineCandidate) },
     { "get_genuines", WRAP(T::GetGenuineCandidates) },
-    { "to_wshadow_candidate", (raw_shadow_candidate<ShadowCandidate>) },
+    { "to_shadow_candidate", (raw_shadow_candidate<ShadowCandidate>) },
     { "to_wshadow_candidate", (raw_shadow_candidate<WShadowCandidate>) },
     { "to_uniquified_candidate", (raw_uniquified_candidate) },
     { "to_phrase", WRAP(candidate_to_<Phrase>)},


### PR DESCRIPTION
```lua
wscand = WShadowCandidate(cand, type) --  WShadow(cand, type [,text [, comment[,  inherit_comment]]])
wscand:get_dynamic_type()  --> "WShadow"
wscand.text= "test"

wscand.comment = "test_comment"
wscand.preedit = "test_preedit" 
```

```
[0][./lua/selector.lua:43] → scand = ShadowCandidate(ctx:get_selected_candidate(), "tt")
7LuaTypeISt10shared_ptrIN4rime9CandidateEEE: 0x614fb89656d8
[0][./lua/selector.lua:43] → scand.text=33
"明"
[0][./lua/selector.lua:43] → scand.text=44
"明"
[0][./lua/selector.lua:43] → scand.comment
""
[0][./lua/selector.lua:43] → scand.comment=333
""
[0][./lua/selector.lua:43] → scand.preedit
"ab     （日月）"
[0][./lua/selector.lua:43] → scand.preedit=333333
"ab     （日月）"
[0][./lua/selector.lua:43] → wscand = WShadowCandidate(ctx:get_selected_candidate(), "tt")
7LuaTypeISt10shared_ptrIN4rime9CandidateEEE: 0x614fb8be37f8
[0][./lua/selector.lua:43] → wscand.text=3
"3"
[0][./lua/selector.lua:43] → wscand.comment=33
"33"
[0][./lua/selector.lua:43] → wscand.preedit=333
"333"
```