### PR TITLE
new parameter for KeyEvent()

### DIFF
--- a/contrib/librime.lua
+++ b/contrib/librime.lua
@@ -318,7 +318,7 @@ function ConfigValue(value) end
 ---@field eq fun(self: self, key: KeyEvent): boolean
 ---@field lt fun(self: self, key: KeyEvent): boolean
 
----@param repr string
+---@param repr string | integer | KeyEvent
 ---@return KeyEvent
 function KeyEvent(repr) end
 

--- a/src/types.cc
+++ b/src/types.cc
@@ -560,8 +560,17 @@ namespace KeyEventReg {
   int raw_make(lua_State *L) {
     an<T> res;
     int n = lua_gettop(L);
-    if (n == 1)
-      res = New<T>( string(lua_tostring(L, 1)) );
+    if (n == 1) {
+      auto type= lua_type(L, 1);
+      if (type == LUA_TUSERDATA) {
+        auto k = LuaType<T&>::todata(L, 1);
+        res= New<T>(k.keycode(), k.modifier());
+      }
+      else if (type== LUA_TNUMBER)
+        res= New<T>(lua_tointeger(L, 1), 0);
+      else if (type == LUA_TSTRING)
+        res= New<T>(lua_tostring(L, 1));
+    }
     else if (n > 1)
       res = New<T>( lua_tointeger(L, 1), lua_tointeger(L, 2) );
 


### PR DESCRIPTION
新增 KeyEvent() 參數
KeyEvent(  [ string | int | KeyEvent [, int]] ) 
key= KeyEvent("A")
KeyEvent(0x41, 1) --> (keycode, modifier)  "Shift+A"
-- 新者參數
keyEvent(0x41) -->  KeyEvent(0x41, 0)
KeyEvent( key) -- clone key 
