### PR TITLE
feat: expose per-Candidate data

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -300,6 +300,40 @@ namespace CandidateReg {
     return spans;
   }
 
+  int raw_get_lua_data(lua_State *L) {
+    an<Candidate>& cand = LuaType<an<Candidate> &>::todata(L, 1);
+    if (auto obj = std::static_pointer_cast<LuaObj>(cand->get_data("_lua_data"))) {
+      LuaType<an<LuaObj>>::pushdata(L, obj);
+    } else {
+      lua_pushnil(L);
+    }
+    return 1;
+  }
+
+  int raw_set_lua_data(lua_State *L) {
+    C_State C;
+    int n = lua_gettop(L);
+    an<Candidate>& cand = LuaType<an<Candidate>& >::todata(L, 1);
+
+    // The candidate can outlive the translation. Upon the destruction
+    // of LuaTranslation, GC will free the thread's
+    // lua_State. Therefore, the data should be registered in the main
+    // thread.
+    lua_rawgeti(L, LUA_REGISTRYINDEX, LUA_RIDX_MAINTHREAD);
+    lua_State* main_L = lua_tothread(L, -1);
+    lua_pop(L, 1);
+
+    // Move the lua data from thread L to main_L
+    lua_xmove(L, main_L, 1);
+
+    // Create the LuaObj using main_L
+    an<LuaObj> obj = LuaObj::todata(main_L, -1);
+    lua_pop(main_L, 1);
+
+    cand->set_data("_lua_data", std::static_pointer_cast<void>(obj));
+    return 0;
+  }
+
   template<class OT>
   an<OT> candidate_to_(an<T> t) {
     return std::dynamic_pointer_cast<OT>(t);
@@ -334,6 +368,7 @@ namespace CandidateReg {
     { "text", WRAPMEM(T, text) },
     { "comment", WRAPMEM(T, comment) },
     { "preedit", WRAPMEM(T, preedit) },
+    { "lua_data", (raw_get_lua_data) },
     { NULL, NULL },
   };
 
@@ -346,6 +381,7 @@ namespace CandidateReg {
     { "text", WRAP(set_text) },
     { "comment", WRAP(set_comment) },
     { "preedit", WRAP(set_preedit) },
+    { "lua_data", (raw_set_lua_data) },
     { NULL, NULL },
   };
 }


### PR DESCRIPTION
需配合 https://github.com/rime/librime/pull/1092 。利用該接口可以比較輕鬆地實現任意 Action Candidate。

一個可能的用例是：

```
local top = {}

function top.init(env)
   local function on_select_pre(ctx)
      local c = ctx:get_selected_candidate()
      if c.lua_data and c.lua_data.launcher_callback then
         ctx:set_option("dumb", true)
         c.lua_data.launcher_callback(env, ctx)
      end
   end
   local function on_select_post(ctx)
      if ctx:get_option("dumb") then
         ctx:set_option("dumb", false)
      end
   end
   env.engine.context.select_notifier:connect(on_select_pre, 0)
   env.engine.context.select_notifier:connect(on_select_post)
end

function top.fini(env)
   collectgarbage()
end

local commands = {
   ['J'] = {
      prompt = '切换到简体',
      action = function(env, ctx) ctx:set_option("simplification", true) end,
   },
   ['F'] = {
      prompt = '切换到繁体',
      action = function(env, ctx) ctx:set_option("simplification", false) end,
   }
}

function top.func(input, seg, env)
   local cmd = commands[input]
   if not cmd then
      return
   end
   local c = Candidate('action', seg._start, seg._end, cmd.prompt, '')
   c.lua_data = c.lua_data or {}
   c.lua_data.launcher_callback = cmd.action
   yield(c)
end

return top
```

效果：

<img width="961" height="751" alt="image" src="https://github.com/user-attachments/assets/bc17b9da-c509-42c9-92f5-4a89d22d873c" />
