### PR TITLE
fix: fallback to shared_data_dir when loading ReverseDb

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -51,7 +51,15 @@ template<typename T, typename = void>
 struct COMPAT {
   // fallback version if librime is old
   static an<ReverseDb> new_ReverseDb(const std::string &file) {
-    return New<ReverseDb>(string(rime_get_api()->get_user_data_dir()) + "/" + file);
+    string target_path = string(rime_get_api()->get_user_data_dir()) + "/" + file;
+    string shared_path = string(rime_get_api()->get_shared_data_dir()) + "/" + file;
+
+    if (!std::filesystem::exists(target_path) &&
+        std::filesystem::exists(shared_path)) {
+      target_path = shared_path;
+    }
+
+    return New<ReverseDb>(target_path);
   }
 
   static string get_shared_data_dir() {
@@ -75,7 +83,16 @@ template<typename T>
 struct COMPAT<T, void_t<decltype(std::declval<T>().user_data_dir.string())>> {
   static an<ReverseDb> new_ReverseDb(const std::string &file) {
     T &deployer = Service::instance().deployer();
-    return New<ReverseDb>(deployer.user_data_dir / file);
+
+    path target_path = deployer.user_data_dir / file;
+    path shared_path = deployer.shared_data_dir / file;
+
+    if (!std::filesystem::exists(target_path) &&
+        std::filesystem::exists(shared_path)) {
+      target_path = shared_path;
+    }
+
+    return New<ReverseDb>(target_path);
   }
 
   static string get_shared_data_dir() {


### PR DESCRIPTION
## Problem

`ReverseDb` only searches `user_data_dir`, but some packaged deployments place read-only db files in `shared_data_dir`.

A concrete example is iDvel/rime-ice#1526, which rewrote `lunar.lua` to use `ReverseDb("lua/lunar.db")`. On Arch Linux, that db is packaged at `/usr/share/rime-data/lua/lunar.db` (see [`rime-ice-git` package on AUR](https://aur.archlinux.org/packages/rime-ice-git)). As a result, the file is not found and the lunar feature does not work.

## Change

When loading `ReverseDb`, keep `user_data_dir` as the first choice. If the target file does not exist, fall back to `shared_data_dir`.

Apply the same logic to both `COMPAT` branches.