### PR TITLE
perf: Amortize GC latency

### DIFF
--- a/src/lib/lua.cc
+++ b/src/lib/lua.cc
@@ -268,6 +268,10 @@ void Lua::gc() {
   lua_gc(L_, LUA_GCCOLLECT, 0);
 }
 
+void Lua::gc_step(int kb) {
+  lua_gc(L_, LUA_GCSTEP, kb);
+}
+
 LuaObj::LuaObj(lua_State *L, int i) : L_(L) {
   lua_pushvalue(L, i);
   id_ = luaL_ref(L, LUA_REGISTRYINDEX);

--- a/src/lib/lua.h
+++ b/src/lib/lua.h
@@ -35,6 +35,7 @@ public:
   std::shared_ptr<LuaObj> newthreadx(lua_State *L, int nargs);
 
   void gc();
+  void gc_step(int kb);
 
   template <typename ... I>
   std::shared_ptr<LuaObj> newthread(I ... input);

--- a/src/lua_gears.cc
+++ b/src/lua_gears.cc
@@ -1,5 +1,6 @@
 #include "lib/lua_templates.h"
 #include "lua_gears.h"
+#include <atomic>
 #include <vector>
 #include <sstream>
 
@@ -24,7 +25,13 @@ bool LuaTranslation::Next() {
 }
 
 LuaTranslation::~LuaTranslation() {
-  lua_->gc();
+  static std::atomic<unsigned int> counter {0};
+  int c = counter.fetch_add(1, std::memory_order_relaxed);
+  if (c % 256 == 0) {
+    lua_->gc();
+  } else {
+    lua_->gc_step(32);
+  }
 }
 
 static std::vector<std::string> split_string(const std::string& str, const std::string& delimiter) {


### PR DESCRIPTION
follow-up: https://github.com/hchunhui/librime-lua/pull/308
follow-up: https://github.com/hchunhui/librime-lua/pull/396

## 变更

在 #396 的基础上引入 step(32) 从而均摊 full gc 的延迟

## 现有问题

目前每次 LuaTranslation 析构都会触发一次 full gc。若 lua 中有较大 table，每次 full gc 都会扫描一遍。实测显示我这里每次 full gc 有至少 1ms 的延迟，则每增加一个 lua filter，都会增加 1ms 的延迟，有明显体感。事实上，该延迟还可能因各种因素叠加（如 lua 中状态积累导致扫描的对象数量越来越多），最终总按键延迟可能超过 10ms 乃至更多。

## 变更后效果

1. 大多数按键延迟大大降低：大部分 step gc 耗时为 0，故大部分按键延迟为 0。
2. 即使 step gc 耗时非 0，实际耗时也往往在 6ms 以下，10ms 以上的延迟极少。对用户来说感知并不明显。
3. 内存占用较为稳定，我这里约在 40MB +- 10MB 间。但相比每次都进行 full gc 来说波动增加了。
